### PR TITLE
Update to hugo 0.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,12 @@ RUN apt-get -qq update \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Download and install hugo
-ENV HUGO_VERSION 0.15
-ENV HUGO_BINARY hugo_${HUGO_VERSION}_linux_amd64
+ENV HUGO_VERSION 0.16
+ENV HUGO_BINARY hugo_${HUGO_VERSION}-1_amd64.deb
 
-ADD https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY}.tar.gz /usr/local/
-RUN tar xzf /usr/local/${HUGO_BINARY}.tar.gz -C /usr/local/ \
-	&& ln -s /usr/local/${HUGO_BINARY}/${HUGO_BINARY} /usr/local/bin/hugo \
-	&& rm /usr/local/${HUGO_BINARY}.tar.gz
+ADD https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY} /usr/local/
+RUN dpkg -i /usr/local/${HUGO_BINARY}/${HUGO_BINARY} \
+	&& rm /usr/local/${HUGO_BINARY}
 
 # Create working directory
 RUN mkdir /usr/share/blog


### PR DESCRIPTION
Also use the new Debian package as it is smaller in size since it's stripped of the debug symbols.

https://github.com/spf13/hugo/releases/tag/v0.16
